### PR TITLE
feature/BD-OtherItem create 2 method get other item

### DIFF
--- a/controllers/otheritemController/getOtherItem.controller.js
+++ b/controllers/otheritemController/getOtherItem.controller.js
@@ -1,0 +1,17 @@
+import { getAllOtherItemService } from '../../services/otheritemServices/getOtherItemService.service.js';
+
+export const getOtherItemController = async (req, res) => {
+  try {
+    const otherItems = await getAllOtherItemService();
+    return res.status(200).json({
+      message: 'List of all other items exist in the database',
+      success: true,
+      data: otherItems,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      message: 'Internal server error',
+      error: error.message,
+    });
+  }
+};

--- a/controllers/otheritemController/getOtherItemById.controller.js
+++ b/controllers/otheritemController/getOtherItemById.controller.js
@@ -1,0 +1,26 @@
+import { getOtherItemByIdService } from '../../services/otheritemServices/getOtherItemByIdService.service.js';
+
+export const getOtherItemByIdController = async (req, res) => {
+  try {
+    const { itemId } = req.params;
+    const existingOtherItem = await getOtherItemByIdService(itemId);
+    if (
+      existingOtherItem === `OtherItem with ID ${itemId} does not exist`
+    ) {
+      return res.status(404).json({
+        message: existingOtherItem,
+        success: false,
+      });
+    }
+    return res.status(200).json({
+      message: `OtherItem with ID ${itemId} found`,
+      success: true,
+      data: existingOtherItem,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      message: 'Internal server error',
+      error: error.message,
+    });
+  }
+};

--- a/routes/otheritem.route.js
+++ b/routes/otheritem.route.js
@@ -1,8 +1,12 @@
 import express from 'express';
 import { createOtherItem } from '../controllers/otheritemController/createOtherItem.controller.js';
+import { getOtherItemController } from '../controllers/otheritemController/getOtherItem.controller.js';
+import { getOtherItemByIdController } from '../controllers/otheritemController/getOtherItemById.controller.js';
 
 const router = express.Router();
 
 router.post('/register', createOtherItem);
+router.get('/otheritems', getOtherItemController);
+router.get('/otheritems/:itemId', getOtherItemByIdController);
 
 export default router;

--- a/services/otheritemServices/getOtherItemByIdService.service.js
+++ b/services/otheritemServices/getOtherItemByIdService.service.js
@@ -1,0 +1,14 @@
+import { OtherItem } from '../../models/otherItem.model.js';
+
+export const getOtherItemByIdService = async (itemId) => {
+  // eslint-disable-next-line no-useless-catch
+  try {
+    const existingItem = await OtherItem.findOne({ item_id: itemId });
+    if (!existingItem) {
+      return `OtherItem with ID ${itemId} does not exist`;
+    }
+    return existingItem;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/services/otheritemServices/getOtherItemService.service.js
+++ b/services/otheritemServices/getOtherItemService.service.js
@@ -1,0 +1,11 @@
+import { OtherItem } from '../../models/otherItem.model.js';
+
+export const getAllOtherItemService = async () => {
+  // eslint-disable-next-line no-useless-catch
+  try {
+    const otherItems = await OtherItem.find();
+    return otherItems;
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
## 1. Overview, Related Documents and Links
<!-- PR summary and description of relevant documents  -->
<!-- If you have a link to Confluence, please include it. -->
This pull request introduces 2 methods: `get all other items` and `get other items by id` allows the user to view all other items or other item with id if needed.
## 2. Details of Change
<!-- Description of changes -->
<!-- Please reiterate important points even if they have already described in the Confluence. -->
deleted some line of `otheritem.route.js` because system doesn't need to use it yet
## 3. Scope of Impact
<!-- I modified this fuction, so this function is also affected, etc. -->
- controller
- services
- routes
## 4. Operating Requirements
<!-- Environment variables / Dependencies / DB updates required / etc. -->
<!-- Please describe any commands that need to executed. -->
<!-- rails db:migrate / rake foo:bar / npm install / etc. -->

## 5. Method of Ensuring Functionality
<!-- Implementation of unit tests and manual testing. Please describe the manual test in detail. -->
Method http:
```
GET
```
Test API:
- case get all other items:
```
http://localhost:3000/api/v1/otheritem/otheritems
```
- case get other item by id:
```
http://localhost:3000/api/v1/otheritem/otheritems/<id>
```
where `<id>` is replaced with id of other item to be viewed
## 6. Remarks
